### PR TITLE
ext4_block_group.h: fix lack of extern "C" closing brace

### DIFF
--- a/include/ext4_block_group.h
+++ b/include/ext4_block_group.h
@@ -319,6 +319,10 @@ static inline void ext4_bg_clear_flag(struct ext4_bgroup *bg, uint32_t f)
  * @return Computed CRC16*/
 uint16_t ext4_bg_crc16(uint16_t crc, const uint8_t *buffer, size_t len);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* EXT4_BLOCK_GROUP_H_ */
 
 /**


### PR DESCRIPTION
There is missing extern "C" closing brace. This commit fixes that small omission.