### PR TITLE
ext4: easy malloc/calloc/realloc/free substitution

### DIFF
--- a/include/ext4_config.h
+++ b/include/ext4_config.h
@@ -149,6 +149,13 @@ extern "C" {
 #ifndef CONFIG_UNALIGNED_ACCESS
 #define CONFIG_UNALIGNED_ACCESS 0
 #endif
+
+/**@brief Switches use of malloc/free functions family
+ *        from standard library to user provided*/
+#ifndef CONFIG_USE_USER_MALLOC
+#define CONFIG_USE_USER_MALLOC 0
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/ext4_types.h
+++ b/include/ext4_types.h
@@ -1004,6 +1004,24 @@ struct jbd_sb {
 }
 #endif
 
+
+#ifdef USE_OTHER_MALLOC
+
+#define ext4_malloc  pool_malloc
+#define ext4_calloc  pool_calloc
+#define ext4_realloc pool_realloc
+#define ext4_free    pool_free
+
+#else
+
+#define ext4_malloc  malloc
+#define ext4_calloc  calloc
+#define ext4_realloc realloc
+#define ext4_free    free
+
+#endif
+
+
 #endif /* EXT4_TYPES_H_ */
 
 /**

--- a/include/ext4_types.h
+++ b/include/ext4_types.h
@@ -1005,12 +1005,12 @@ struct jbd_sb {
 #endif
 
 
-#ifdef USE_OTHER_MALLOC
+#if CONFIG_USE_USER_MALLOC
 
-#define ext4_malloc  pool_malloc
-#define ext4_calloc  pool_calloc
-#define ext4_realloc pool_realloc
-#define ext4_free    pool_free
+#define ext4_malloc  user_malloc
+#define ext4_calloc  user_calloc
+#define ext4_realloc user_realloc
+#define ext4_free    user_free
 
 #else
 

--- a/src/ext4.c
+++ b/src/ext4.c
@@ -395,12 +395,12 @@ int ext4_mount(const char *dev_name, const char *mount_point,
 	if (!bc) {
 		/*Automatic block cache alloc.*/
 		mp->cache_dynamic = 1;
-		bc = malloc(sizeof(struct ext4_bcache));
+		bc = ext4_malloc(sizeof(struct ext4_bcache));
 
 		r = ext4_bcache_init_dynamic(bc, CONFIG_BLOCK_DEV_CACHE_SIZE,
 					     bsize);
 		if (r != EOK) {
-			free(bc);
+			ext4_free(bc);
 			ext4_block_fini(bd);
 			return r;
 		}
@@ -416,7 +416,7 @@ int ext4_mount(const char *dev_name, const char *mount_point,
 		ext4_block_fini(bd);
 		if (mp->cache_dynamic) {
 			ext4_bcache_fini_dynamic(bc);
-			free(bc);
+			ext4_free(bc);
 		}
 		return r;
 	}
@@ -451,7 +451,7 @@ int ext4_umount(const char *mount_point)
 	ext4_bcache_cleanup(mp->fs.bdev->bc);
 	if (mp->cache_dynamic) {
 		ext4_bcache_fini_dynamic(mp->fs.bdev->bc);
-		free(mp->fs.bdev->bc);
+		ext4_free(mp->fs.bdev->bc);
 	}
 	r = ext4_block_fini(mp->fs.bdev);
 Finish:
@@ -549,7 +549,7 @@ static int __ext4_recover(const char *mount_point)
 	int r = ENOTSUP;
 	EXT4_MP_LOCK(mp);
 	if (ext4_sb_feature_com(&mp->fs.sb, EXT4_FCOM_HAS_JOURNAL)) {
-		struct jbd_fs *jbd_fs = calloc(1, sizeof(struct jbd_fs));
+		struct jbd_fs *jbd_fs = ext4_calloc(1, sizeof(struct jbd_fs));
 		if (!jbd_fs) {
 			 r = ENOMEM;
 			 goto Finish;
@@ -558,13 +558,13 @@ static int __ext4_recover(const char *mount_point)
 
 		r = jbd_get_fs(&mp->fs, jbd_fs);
 		if (r != EOK) {
-			free(jbd_fs);
+			ext4_free(jbd_fs);
 			goto Finish;
 		}
 
 		r = jbd_recover(jbd_fs);
 		jbd_put_fs(jbd_fs);
-		free(jbd_fs);
+		ext4_free(jbd_fs);
 	}
 	if (r == EOK && !mp->fs.read_only) {
 		uint32_t bgid;
@@ -2611,7 +2611,7 @@ int ext4_listxattr(const char *path, char *list, size_t size, size_t *ret_size)
 
 	r = ext4_xattr_list(&inode_ref, NULL, &list_len);
 	if (r == EOK && list_len) {
-		xattr_list = malloc(list_len);
+		xattr_list = ext4_malloc(list_len);
 		if (!xattr_list) {
 			ext4_fs_put_inode_ref(&inode_ref);
 			r = ENOMEM;
@@ -2658,7 +2658,7 @@ int ext4_listxattr(const char *path, char *list, size_t size, size_t *ret_size)
 Finish:
 	EXT4_MP_UNLOCK(mp);
 	if (xattr_list)
-		free(xattr_list);
+		ext4_free(xattr_list);
 
 	return r;
 

--- a/src/ext4_bcache.c
+++ b/src/ext4_bcache.c
@@ -35,6 +35,7 @@
  */
 
 #include "ext4_config.h"
+#include "ext4_types.h"
 #include "ext4_bcache.h"
 #include "ext4_blockdev.h"
 #include "ext4_debug.h"
@@ -120,13 +121,13 @@ ext4_buf_alloc(struct ext4_bcache *bc, uint64_t lba)
 {
 	void *data;
 	struct ext4_buf *buf;
-	data = malloc(bc->itemsize);
+	data = ext4_malloc(bc->itemsize);
 	if (!data)
 		return NULL;
 
-	buf = calloc(1, sizeof(struct ext4_buf));
+	buf = ext4_calloc(1, sizeof(struct ext4_buf));
 	if (!buf) {
-		free(data);
+		ext4_free(data);
 		return NULL;
 	}
 
@@ -138,8 +139,8 @@ ext4_buf_alloc(struct ext4_bcache *bc, uint64_t lba)
 
 static void ext4_buf_free(struct ext4_buf *buf)
 {
-	free(buf->data);
-	free(buf);
+	ext4_free(buf->data);
+	ext4_free(buf);
 }
 
 static struct ext4_buf *

--- a/src/ext4_dir_idx.c
+++ b/src/ext4_dir_idx.c
@@ -939,7 +939,7 @@ static int ext4_dir_dx_split_data(struct ext4_inode_ref *inode_ref,
 	uint32_t block_size = ext4_sb_get_block_size(&inode_ref->fs->sb);
 
 	/* Allocate buffer for directory entries */
-	uint8_t *entry_buffer = malloc(block_size);
+	uint8_t *entry_buffer = ext4_malloc(block_size);
 	if (entry_buffer == NULL)
 		return ENOMEM;
 
@@ -949,9 +949,9 @@ static int ext4_dir_dx_split_data(struct ext4_inode_ref *inode_ref,
 	/* Allocate sort entry */
 	struct ext4_dx_sort_entry *sort;
 
-	sort = malloc(max_ecnt * sizeof(struct ext4_dx_sort_entry));
+	sort = ext4_malloc(max_ecnt * sizeof(struct ext4_dx_sort_entry));
 	if (sort == NULL) {
-		free(entry_buffer);
+		ext4_free(entry_buffer);
 		return ENOMEM;
 	}
 
@@ -972,8 +972,8 @@ static int ext4_dir_dx_split_data(struct ext4_inode_ref *inode_ref,
 			rc = ext4_dir_dx_hash_string(&hinfo_tmp, len,
 						     (char *)de->name);
 			if (rc != EOK) {
-				free(sort);
-				free(entry_buffer);
+				ext4_free(sort);
+				ext4_free(entry_buffer);
 				return rc;
 			}
 
@@ -1008,8 +1008,8 @@ static int ext4_dir_dx_split_data(struct ext4_inode_ref *inode_ref,
 	uint32_t new_iblock;
 	rc = ext4_fs_append_inode_dblk(inode_ref, &new_fblock, &new_iblock);
 	if (rc != EOK) {
-		free(sort);
-		free(entry_buffer);
+		ext4_free(sort);
+		ext4_free(entry_buffer);
 		return rc;
 	}
 
@@ -1018,8 +1018,8 @@ static int ext4_dir_dx_split_data(struct ext4_inode_ref *inode_ref,
 	rc = ext4_trans_block_get_noread(inode_ref->fs->bdev, &new_data_block_tmp,
 				   new_fblock);
 	if (rc != EOK) {
-		free(sort);
-		free(entry_buffer);
+		ext4_free(sort);
+		ext4_free(entry_buffer);
 		return rc;
 	}
 
@@ -1097,8 +1097,8 @@ static int ext4_dir_dx_split_data(struct ext4_inode_ref *inode_ref,
 	ext4_trans_set_block_dirty(old_data_block->buf);
 	ext4_trans_set_block_dirty(new_data_block_tmp.buf);
 
-	free(sort);
-	free(entry_buffer);
+	ext4_free(sort);
+	ext4_free(entry_buffer);
 
 	ext4_dir_dx_insert_entry(inode_ref, index_block, new_hash + continued,
 				new_iblock);

--- a/src/ext4_extent.c
+++ b/src/ext4_extent.c
@@ -529,14 +529,14 @@ static int ext4_find_extent(struct ext4_inode_ref *inode_ref, ext4_lblk_t block,
 	if (path) {
 		ext4_ext_drop_refs(inode_ref, path, 0);
 		if (depth > path[0].maxdepth) {
-			free(path);
+			ext4_free(path);
 			*orig_path = path = NULL;
 		}
 	}
 	if (!path) {
 		int32_t path_depth = depth + 1;
 		/* account possible depth increase */
-		path = calloc(1, sizeof(struct ext4_extent_path) *
+		path = ext4_calloc(1, sizeof(struct ext4_extent_path) *
 				     (path_depth + 1));
 		if (!path)
 			return ENOMEM;
@@ -592,7 +592,7 @@ static int ext4_find_extent(struct ext4_inode_ref *inode_ref, ext4_lblk_t block,
 
 err:
 	ext4_ext_drop_refs(inode_ref, path, 0);
-	free(path);
+	ext4_free(path);
 	if (orig_path)
 		*orig_path = NULL;
 	return ret;
@@ -1130,7 +1130,7 @@ again:
 		i = depth - (level - 1);
 		/* We split from leaf to the i-th node */
 		if (level > 0) {
-			npath = calloc(1, sizeof(struct ext4_extent_path) *
+			npath = ext4_calloc(1, sizeof(struct ext4_extent_path) *
 					      (level));
 			if (!npath) {
 				ret = ENOMEM;
@@ -1168,7 +1168,7 @@ out:
 		}
 	}
 	if (npath)
-		free(npath);
+		ext4_free(npath);
 
 	return ret;
 }
@@ -1498,7 +1498,7 @@ int ext4_extent_remove_space(struct ext4_inode_ref *inode_ref, ext4_lblk_t from,
 
 out:
 	ext4_ext_drop_refs(inode_ref, path, 0);
-	free(path);
+	ext4_free(path);
 	path = NULL;
 	return ret;
 }
@@ -1792,7 +1792,7 @@ out:
 out2:
 	if (path) {
 		ext4_ext_drop_refs(inode_ref, path, 0);
-		free(path);
+		ext4_free(path);
 	}
 
 	return err;

--- a/src/ext4_mkfs.c
+++ b/src/ext4_mkfs.c
@@ -176,11 +176,11 @@ static int create_fs_aux_info(struct fs_aux_info *aux_info,
 		aux_info->len_blocks -= last_group_size;
 	}
 
-	aux_info->sb = calloc(1, EXT4_SUPERBLOCK_SIZE);
+	aux_info->sb = ext4_calloc(1, EXT4_SUPERBLOCK_SIZE);
 	if (!aux_info->sb)
 		return ENOMEM;
 
-	aux_info->bg_desc_blk = calloc(1, info->block_size);
+	aux_info->bg_desc_blk = ext4_calloc(1, info->block_size);
 	if (!aux_info->bg_desc_blk)
 		return ENOMEM;
 
@@ -213,9 +213,9 @@ static int create_fs_aux_info(struct fs_aux_info *aux_info,
 static void release_fs_aux_info(struct fs_aux_info *aux_info)
 {
 	if (aux_info->sb)
-		free(aux_info->sb);
+		ext4_free(aux_info->sb);
 	if (aux_info->bg_desc_blk)
-		free(aux_info->bg_desc_blk);
+		ext4_free(aux_info->bg_desc_blk);
 }
 
 
@@ -467,7 +467,7 @@ int ext4_mkfs_read_info(struct ext4_blockdev *bd, struct ext4_mkfs_info *info)
 	if (r != EOK)
 		return r;
 
-	sb = malloc(EXT4_SUPERBLOCK_SIZE);
+	sb = ext4_malloc(EXT4_SUPERBLOCK_SIZE);
 	if (!sb)
 		goto Finish;
 
@@ -480,7 +480,7 @@ int ext4_mkfs_read_info(struct ext4_blockdev *bd, struct ext4_mkfs_info *info)
 
 Finish:
 	if (sb)
-		free(sb);
+		ext4_free(sb);
 	ext4_block_fini(bd);
 	return r;
 }


### PR DESCRIPTION
Sometimes it's helpful to be able to substitute malloc/free (and family) with one easy step.
Here is my proposal to enable such a substitution.

I understand that proposed names and placing of #define's isn't perfect - it's just an idea.