### PR TITLE
Remove an unuseful if check in ext4.c.

### DIFF
--- a/src/ext4.c
+++ b/src/ext4.c
@@ -379,11 +379,9 @@ int ext4_mount(const char *dev_name, const char *mount_point,
 		return ENOTSUP;
 
 	for (size_t i = 0; i < CONFIG_EXT4_BLOCKDEVS_COUNT; ++i) {
-		if (s_bdevices[i].name) {
-			if (!strcmp(dev_name, s_bdevices[i].name)) {
-				bd = s_bdevices[i].bd;
-				break;
-			}
+		if (!strcmp(dev_name, s_bdevices[i].name)) {
+			bd = s_bdevices[i].bd;
+			break;
 		}
 	}
 


### PR DESCRIPTION
The if check on s_bdevices[i].name is unuseful, as 'name' always
evaluates to true:
    if (s_bdevices[i].name) {
        ...
    }
This change removes the check to be consistent with the rest of the code
(see line 124 and 144).