### PR TITLE
Use int64_t as offset to ext4_fseek.

### DIFF
--- a/include/ext4.h
+++ b/include/ext4.h
@@ -368,7 +368,7 @@ int ext4_fwrite(ext4_file *file, const void *buf, size_t size, size_t *wcnt);
  *              @ref SEEK_END
  *
  * @return  Standard error code.*/
-int ext4_fseek(ext4_file *file, uint64_t offset, uint32_t origin);
+int ext4_fseek(ext4_file *file, int64_t offset, uint32_t origin);
 
 /**@brief   Get file position.
  *

--- a/src/ext4.c
+++ b/src/ext4.c
@@ -2016,23 +2016,25 @@ Finish:
 	return r;
 }
 
-int ext4_fseek(ext4_file *file, uint64_t offset, uint32_t origin)
+int ext4_fseek(ext4_file *file, int64_t offset, uint32_t origin)
 {
 	switch (origin) {
 	case SEEK_SET:
-		if (offset > file->fsize)
+		if (offset < 0 || (uint64_t)offset > file->fsize)
 			return EINVAL;
 
 		file->fpos = offset;
 		return EOK;
 	case SEEK_CUR:
-		if ((offset + file->fpos) > file->fsize)
+		if ((offset < 0 && (uint64_t)(-offset) > file->fpos) ||
+		    (offset > 0 &&
+		     (uint64_t)offset > (file->fsize - file->fpos)))
 			return EINVAL;
 
 		file->fpos += offset;
 		return EOK;
 	case SEEK_END:
-		if (offset > file->fsize)
+		if (offset < 0 || (uint64_t)offset > file->fsize)
 			return EINVAL;
 
 		file->fpos = file->fsize - offset;


### PR DESCRIPTION
This change makes it possible to fseek backwards in fseek. It fixes #25 

Please let me know if you would like to have a specific test for the offsets and different origins.

Tested:
  make test_all