### PR TITLE
Fix: ext4-mkfs and ext4-mbr-write use wrong partition size in case of multiple partitions

### DIFF
--- a/src/ext4_mbr.c
+++ b/src/ext4_mbr.c
@@ -129,7 +129,7 @@ int ext4_mbr_scan(struct ext4_blockdev *parent, struct ext4_mbr_bdevs *bdevs)
 int ext4_mbr_write(struct ext4_blockdev *parent, struct ext4_mbr_parts *parts)
 {
 	int r;
-	uint64_t disk_size = parent->part_size;
+	uint64_t disk_size;
 	uint32_t division_sum = parts->division[0] + parts->division[1] +
 				parts->division[2] + parts->division[3];
 
@@ -140,6 +140,8 @@ int ext4_mbr_write(struct ext4_blockdev *parent, struct ext4_mbr_parts *parts)
 	r = ext4_block_init(parent);
 	if (r != EOK)
 		return r;
+
+	disk_size = parent->part_size;
 
 	/*Calculate CHS*/
 	uint32_t k = 16;
@@ -167,7 +169,7 @@ int ext4_mbr_write(struct ext4_blockdev *parent, struct ext4_mbr_parts *parts)
 
 		if (i == 0) {
 			part_start += 63;
-			part_size -= 63;
+			part_size -= 63 * parent->bdif->ph_bsize;
 		}
 
 		uint32_t cyl_end = cyl_part + cyl_it - 1;
@@ -182,7 +184,7 @@ int ext4_mbr_write(struct ext4_blockdev *parent, struct ext4_mbr_parts *parts)
 		mbr->part_entry[i].chs2[2] = cyl_end;
 
 		mbr->part_entry[i].first_lba = part_start;
-		mbr->part_entry[i].sectors = part_size;
+		mbr->part_entry[i].sectors = part_size / parent->bdif->ph_bsize;
 
 		cyl_it += cyl_part;
 	}

--- a/src/ext4_mkfs.c
+++ b/src/ext4_mkfs.c
@@ -709,7 +709,7 @@ int ext4_mkfs(struct ext4_fs *fs, struct ext4_blockdev *bd,
 	bd->fs = fs;
 
 	if (info->len == 0)
-		info->len = bd->bdif->ph_bcnt * bd->bdif->ph_bsize;
+		info->len = bd->part_size;
 
 	if (info->block_size == 0)
 		info->block_size = 4096; /*Set block size to default value*/


### PR DESCRIPTION
Pull request for bugfixes from my ext4-browser project.

ext4_mbr_write:
* parent is not initialized in line 132, will be initialized in line 140.
* part_size has to be adjusted in physical block size.

ext4_mkfs: Use partition size, not whole disk size when formatting partition.