### PR TITLE
CMake: Added option whether to build static or shared library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,14 @@
 
+option(LWEXT4_BUILD_SHARED_LIB "Build shared library" OFF)
+
 #LIBRARY
 include_directories(.)
 aux_source_directory(. LWEXT4_SRC)
-add_library(lwext4 STATIC ${LWEXT4_SRC})
+if(LWEXT4_BUILD_SHARED_LIB)
+  add_library(lwext4 SHARED ${LWEXT4_SRC})
+else()
+  add_library(lwext4 STATIC ${LWEXT4_SRC})
+endif()
 
 if  (DEFINED SIZE)
     add_custom_target(lib_size ALL DEPENDS lwext4 COMMAND ${SIZE} liblwext4.a)


### PR DESCRIPTION
Useful when using lwext4 in non bare-metal projects. The default behaviour is not changed.