### PR TITLE
Raise cmake_minimum_required: 2.8 -> 3.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(lwext4 C)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.4)
 
 
 include_directories(${PROJECT_BINARY_DIR}/include)


### PR DESCRIPTION
This is `0001-Raise-cmake_minimum_required-2.8-3.4.patch` used in the Real World CTF challenge rwext5.

See CMP0065, otherwise -rdynamic is unconditionally added to linked executable. These .dynsym symbols are not really useful.