### PR TITLE
Fix "const const" warning

### DIFF
--- a/fs_test/lwext4_server.c
+++ b/fs_test/lwext4_server.c
@@ -626,7 +626,7 @@ static int file_read(const char *p)
 	return rc;
 }
 
-static int file_write(const const char *p)
+static int file_write(const char *p)
 {
 	int fid = MAX_FILES;
 	int d;


### PR DESCRIPTION
This is `0002-Fix-const-const-warning.patch` used in the Real World CTF challenge rwext5.