### PR TITLE
Change badges to reflect project license status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Join the chat at https://gitter.im/gkostka/lwext4](https://badges.gitter.im/gkostka/lwext4.svg)](https://gitter.im/gkostka/lwext4?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![License (3-Clause BSD)](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg?style=flat-square)](http://opensource.org/licenses/BSD-3-Clause)
+[![License (GPL v2.0)](https://img.shields.io/badge/license-GPL%20(v2.0)-blue.svg?style=flat-square)](http://opensource.org/licenses/GPL-2.0)
 [![Build Status](https://travis-ci.org/gkostka/lwext4.svg)](https://travis-ci.org/gkostka/lwext4)
 [![](http://img.shields.io/gratipay/user/gkostka.svg)](https://gratipay.com/gkostka/)
 


### PR DESCRIPTION
While all source files except the two mentioned (ext4_xattr.c and ext4_extents.c) are BSD-3-clause, and it seems like this project may be licensed as such by removing those two files, the project license should be reflected as GPL v2.0, in accordance with the LICENSE file at the root of the project.