### PR TITLE
ext4: Fix ext4_mount

### DIFF
--- a/src/ext4.c
+++ b/src/ext4.c
@@ -391,7 +391,6 @@ int ext4_mount(const char *dev_name, const char *mount_point,
 	for (size_t i = 0; i < CONFIG_EXT4_MOUNTPOINTS_COUNT; ++i) {
 		if (!s_mp[i].mounted) {
 			strcpy(s_mp[i].name, mount_point);
-			s_mp[i].mounted = 1;
 			mp = &s_mp[i];
 			break;
 		}
@@ -436,6 +435,7 @@ int ext4_mount(const char *dev_name, const char *mount_point,
 	}
 
 	bd->fs = &mp->fs;
+    mp->mounted = 1;
 	return r;
 }
 

--- a/src/ext4.c
+++ b/src/ext4.c
@@ -435,7 +435,7 @@ int ext4_mount(const char *dev_name, const char *mount_point,
 	}
 
 	bd->fs = &mp->fs;
-    mp->mounted = 1;
+	mp->mounted = 1;
 	return r;
 }
 


### PR DESCRIPTION
When calling ext4_mount twice with the same parameters, but with an invalid file system (e.g. not formatted), the second call automatically succeeds and subsequent fs calls will use a corrupt mount point.