### PR TITLE
Fix ext4_device_unregister return code

### DIFF
--- a/src/ext4.c
+++ b/src/ext4.c
@@ -145,6 +145,7 @@ int ext4_device_unregister(const char *dev_name)
 			continue;
 
 		memset(&s_bdevices[i], 0, sizeof(s_bdevices[i]));
+		return EOK;
 	}
 
 	return ENOENT;


### PR DESCRIPTION
ext4_device_unregister always returned ENOENT, even if the operation was successful.