### PR TITLE
dir_idx: initialize entry inode before calculating csum

### DIFF
--- a/src/ext4_dir_idx.c
+++ b/src/ext4_dir_idx.c
@@ -433,6 +433,8 @@ int ext4_dir_dx_init(struct ext4_inode_ref *dir, struct ext4_inode_ref *parent)
 	/* Fill the whole block with empty entry */
 	struct ext4_dir_en *be = (void *)new_block.data;
 
+	ext4_dir_en_set_inode(be, 0);
+
 	if (ext4_sb_feature_ro_com(sb, EXT4_FRO_COM_METADATA_CSUM)) {
 		uint16_t len = block_size - sizeof(struct ext4_dir_entry_tail);
 		ext4_dir_en_set_entry_len(be, len);
@@ -443,8 +445,6 @@ int ext4_dir_dx_init(struct ext4_inode_ref *dir, struct ext4_inode_ref *parent)
 	} else {
 		ext4_dir_en_set_entry_len(be, block_size);
 	}
-
-	ext4_dir_en_set_inode(be, 0);
 
 	ext4_trans_set_block_dirty(new_block.buf);
 	rc = ext4_block_set(dir->fs->bdev, &new_block);


### PR DESCRIPTION
When new directory is created and initialized (see `ext4_link()` and `ext4_trunc_dir()`), the `csum` is calculated before the inode is set to 0 and results in corrupt checksum. This affects only empty directories because as soon as new entries get added to a directory, the `csum` gets updated to new correct value.

This PR moves the setting of the inode before calculating the `csum`.