### PR TITLE
Fix static analysis issues found by cppcheck

### DIFF
--- a/include/ext4_trans.h
+++ b/include/ext4_trans.h
@@ -34,8 +34,8 @@
  * @brief Transaction handle functions
  */
 
-#ifndef EXT4_TRANS_H
-#define EXT4_TRANS_H
+#ifndef EXT4_TRANS_H_
+#define EXT4_TRANS_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -83,7 +83,7 @@ int ext4_trans_try_revoke_block(struct ext4_blockdev *bdev,
 }
 #endif
 
-#endif /* EXT4_TRANS_H */
+#endif /* EXT4_TRANS_H_ */
 
 /**
  * @}

--- a/src/ext4_extent.c
+++ b/src/ext4_extent.c
@@ -662,7 +662,7 @@ static int ext4_ext_split_node(struct ext4_inode_ref *inode_ref,
 			struct ext4_extent_index *ix;
 			ix = EXT_FIRST_INDEX(neh);
 			memmove(ix, path[at].index + 1,
-				sizeof(struct ext4_extent) * m);
+				sizeof(struct ext4_extent_index) * m);
 			neh->entries_count =
 			    to_le16(to_le16(neh->entries_count) + m);
 			path[at].header->entries_count = to_le16(

--- a/src/ext4_journal.c
+++ b/src/ext4_journal.c
@@ -46,7 +46,6 @@
 #include "ext4_journal.h"
 #include "ext4_blockdev.h"
 #include "ext4_crc32.h"
-#include "ext4_journal.h"
 
 #include <string.h>
 #include <stdlib.h>

--- a/src/ext4_mkfs.c
+++ b/src/ext4_mkfs.c
@@ -357,7 +357,7 @@ static void fill_bgroups(struct fs_aux_info *aux_info,
 static int write_bgroups(struct ext4_blockdev *bd, struct fs_aux_info *aux_info,
 			 struct ext4_mkfs_info *info)
 {
-	int r;
+	int r = EOK;
 	uint32_t i;
 	struct ext4_block b;
 	for (i = 0; i < aux_info->groups; i++) {


### PR DESCRIPTION
## Summary
This PR fixes issues identified by static analysis using cppcheck 2.7.

## Changes

### 1. Fix uninitialized variable (ext4_mkfs.c:360)
Initialize `r = EOK` in `write_bgroups()` to prevent undefined behavior
when `aux_info->groups == 0`.

### 2. Fix wrong sizeof (ext4_extent.c:665)
Use `sizeof(struct ext4_extent_index)` instead of `sizeof(struct ext4_extent)`
when moving extent indices in `ext4_ext_split_node()`.

### 3. Remove duplicate include (ext4_journal.c)
`ext4_journal.h` was included twice.

### 4. Fix include guard style (ext4_trans.h)
Use `EXT4_TRANS_H_` to match convention of all other headers.

## Verification
- [x] Builds without warnings
- [x] cppcheck shows no errors after fix

🤖 Generated with [Claude Code](https://claude.ai/code)