### PR TITLE
Fix several issues found by fuzzing

### DIFF
--- a/include/ext4_dir.h
+++ b/include/ext4_dir.h
@@ -123,6 +123,9 @@ static inline void ext4_dir_en_set_entry_len(struct ext4_dir_en *de, uint16_t l)
 static inline uint16_t ext4_dir_en_get_name_len(struct ext4_sblock *sb,
 						struct ext4_dir_en *de)
 {
+	if(de == NULL)
+		return 0;
+
 	uint16_t v = de->name_len;
 
 	if ((ext4_get32(sb, rev_level) == 0) &&

--- a/src/ext4.c
+++ b/src/ext4.c
@@ -414,6 +414,10 @@ int ext4_mount(const char *dev_name, const char *mount_point,
 	}
 
 	bsize = ext4_sb_get_block_size(&mp->fs.sb);
+	/* Standard size 4KiB, max block size 64KiB  (bounds 1KiB - 64KiB) */
+	if(bsize < 1024 || bsize > 0x10000)
+		return ENOTSUP;
+
 	ext4_block_set_lb_size(bd, bsize);
 	bc = &mp->bc;
 

--- a/src/ext4_bcache.c
+++ b/src/ext4_bcache.c
@@ -165,6 +165,12 @@ void ext4_bcache_drop_buf(struct ext4_bcache *bc, struct ext4_buf *buf)
 		ext4_dbg(DEBUG_BCACHE, DBG_WARN "Buffer is still referenced. "
 				"lba: %" PRIu64 ", refctr: %" PRIu32 "\n",
 				buf->lba, buf->refctr);
+
+		/* Try to remove block anyway to avoid double free
+		 * Needs to be tested carefuly! Potentially not safe!
+		 */
+		buf->refctr = 0;
+		RB_REMOVE(ext4_buf_lru, &bc->lru_root, buf);
 	} else
 		RB_REMOVE(ext4_buf_lru, &bc->lru_root, buf);
 

--- a/src/ext4_extent.c
+++ b/src/ext4_extent.c
@@ -886,8 +886,16 @@ static int ext4_find_extent(struct ext4_inode_ref *inode_ref, ext4_lblk_t block,
 	path[0].block = bh;
 
 	i = depth;
+
+	uint16_t max_entries = to_le16(ext4_ext_max_entries(inode_ref, depth));
+
 	/* walk through the tree */
 	while (i) {
+		max_entries = to_le16(ext4_ext_max_entries(inode_ref, i));
+		if(max_entries < path[ppos].header->entries_count) {
+			ret = EIO;
+			goto err;
+		}
 		ext4_ext_binsearch_idx(path + ppos, block);
 		path[ppos].p_block = ext4_idx_pblock(path[ppos].index);
 		path[ppos].depth = i;
@@ -918,6 +926,14 @@ static int ext4_find_extent(struct ext4_inode_ref *inode_ref, ext4_lblk_t block,
 	path[ppos].depth = i;
 	path[ppos].extent = NULL;
 	path[ppos].index = NULL;
+
+	depth = i;
+	max_entries = to_le16(ext4_ext_max_entries(inode_ref, depth));
+
+	if(max_entries < path[ppos].header->entries_count) {
+		ret = EIO;
+		goto err;
+	}
 
 	/* find extent */
 	ext4_ext_binsearch(path + ppos, block);

--- a/src/ext4_fs.c
+++ b/src/ext4_fs.c
@@ -329,6 +329,10 @@ static int ext4_fs_init_block_bitmap(struct ext4_block_group_ref *bg_ref)
 	} else { /* For META_BG_BLOCK_GROUPS */
 		bit_max += ext4_bg_num_gdb(sb, bg_ref->index);
 	}
+
+	if((bit_max >> 3) > block_size)
+		return ENXIO;
+
 	for (bit = 0; bit < bit_max; bit++)
 		ext4_bmap_bit_set(block_bitmap.data, bit);
 
@@ -398,8 +402,13 @@ static int ext4_fs_init_inode_bitmap(struct ext4_block_group_ref *bg_ref)
 		return rc;
 
 	/* Initialize all bitmap bits to zero */
+	/* MAX block size 64Kib standard 4KiB (bounds 1KiB - 64KiB) */
 	uint32_t block_size = ext4_sb_get_block_size(sb);
 	uint32_t inodes_per_group = ext4_get32(sb, inodes_per_group);
+
+	/* b.data has size of block_size when mount, so check */
+	if(((inodes_per_group + 7) / 8) > block_size)
+		return EFAULT;
 
 	memset(b.data, 0, (inodes_per_group + 7) / 8);
 


### PR DESCRIPTION
There are several issues found by fuzz testing lwext4:
1. Out-of-Bounds Read in ext4_ext_binsearch_idx()
2. NULL pointer dereference in ext4_dir_en_get_name_len
3. FPE in ext4_block_set_lb_size()
4. Out-of-Bounds Write in ext4_bmap_bit_set()
5. Double-Free in ext4_bcache_drop_buf()

This patchset fixes the following issues:
1. #89
2. #90 
3. #91 
4. #92 
5. #93 